### PR TITLE
emit writefile event instead of finish

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,7 @@ module.exports = function SwiftStore(globalOpts) {
 
 				newFile.on('end', (err, value) => {
 					debug('Finished uploading %s', filename);
-					receiver.emit('finish', err, value);
+					receiver.emit('writefile', newFile);
 					done();
 				});
 			};


### PR DESCRIPTION
When a new file is correctly uploaded, we should emit a writefile event, not finish as there might be other files to process.